### PR TITLE
Add team and organization management resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,48 @@ resource "make_webhook" "example" {
 - `id` - Webhook identifier
 - `url` - URL endpoint for the webhook
 
+### make_team
+
+Manages Make.com teams.
+
+#### Example Usage
+
+```hcl
+resource "make_team" "example" {
+  name            = "Engineering Team"
+  organization_id = "org-123"
+}
+```
+
+#### Arguments
+
+- `name` (Required) - Name of the team
+- `organization_id` (Optional) - Organization ID where the team belongs
+
+#### Attributes
+
+- `id` - Team identifier
+
+### make_organization
+
+Manages Make.com organizations.
+
+#### Example Usage
+
+```hcl
+resource "make_organization" "example" {
+  name = "Example Org"
+}
+```
+
+#### Arguments
+
+- `name` (Required) - Name of the organization
+
+#### Attributes
+
+- `id` - Organization identifier
+
 ## Available Data Sources
 
 ### make_scenario
@@ -212,6 +254,47 @@ data "make_connection" "example" {
 - `app_name` - Name of the app for this connection
 - `team_id` - Team ID where the connection belongs
 - `verified` - Whether the connection is verified
+
+### make_team
+
+Reads information about an existing Make.com team.
+
+#### Example Usage
+
+```hcl
+data "make_team" "example" {
+  id = "team-id-123"
+}
+```
+
+#### Arguments
+
+- `id` (Required) - Team identifier
+
+#### Attributes
+
+- `name` - Name of the team
+- `organization_id` - Organization ID where the team belongs
+
+### make_organization
+
+Reads information about an existing Make.com organization.
+
+#### Example Usage
+
+```hcl
+data "make_organization" "example" {
+  id = "org-id-123"
+}
+```
+
+#### Arguments
+
+- `id` (Required) - Organization identifier
+
+#### Attributes
+
+- `name` - Name of the organization
 
 ## Developing the Provider
 
@@ -266,7 +349,7 @@ This provider is designed to work with the Make.com API. For more information ab
 - [x] Implement actual API calls to Make.com endpoints
 - [x] Add enhanced error handling and validation
 - [x] Add basic test coverage
-- [ ] Add team and organization management
+- [x] Add team and organization management
 - [ ] Add data store management
 - [ ] Add more comprehensive test coverage including acceptance tests
 - [ ] Add advanced configuration options for webhooks and connections

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -406,3 +406,209 @@ func (c *MakeAPIClient) DeleteWebhook(ctx context.Context, id string) error {
 
 	return nil
 }
+
+// TeamResponse represents a Make.com team from the API
+type TeamResponse struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	OrganizationID string `json:"organization_id,omitempty"`
+}
+
+// TeamRequest represents the request payload for creating/updating teams
+type TeamRequest struct {
+	Name           string `json:"name"`
+	OrganizationID string `json:"organization_id,omitempty"`
+}
+
+// CreateTeam creates a new team in Make.com
+func (c *MakeAPIClient) CreateTeam(ctx context.Context, req TeamRequest) (*TeamResponse, error) {
+	resp, err := c.MakeRequest(ctx, "POST", "v2/teams", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, c.HandleErrorResponse(resp)
+	}
+
+	var team TeamResponse
+	if err := json.NewDecoder(resp.Body).Decode(&team); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &team, nil
+}
+
+// GetTeam retrieves a team by ID from Make.com
+func (c *MakeAPIClient) GetTeam(ctx context.Context, id string) (*TeamResponse, error) {
+	endpoint := fmt.Sprintf("v2/teams/%s", id)
+	resp, err := c.MakeRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("team with ID %s not found", id)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, c.HandleErrorResponse(resp)
+	}
+
+	var team TeamResponse
+	if err := json.NewDecoder(resp.Body).Decode(&team); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &team, nil
+}
+
+// UpdateTeam updates an existing team in Make.com
+func (c *MakeAPIClient) UpdateTeam(ctx context.Context, id string, req TeamRequest) (*TeamResponse, error) {
+	endpoint := fmt.Sprintf("v2/teams/%s", id)
+	resp, err := c.MakeRequest(ctx, "PUT", endpoint, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("team with ID %s not found", id)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, c.HandleErrorResponse(resp)
+	}
+
+	var team TeamResponse
+	if err := json.NewDecoder(resp.Body).Decode(&team); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &team, nil
+}
+
+// DeleteTeam deletes a team from Make.com
+func (c *MakeAPIClient) DeleteTeam(ctx context.Context, id string) error {
+	endpoint := fmt.Sprintf("v2/teams/%s", id)
+	resp, err := c.MakeRequest(ctx, "DELETE", endpoint, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		// Already deleted or doesn't exist
+		return nil
+	}
+
+	if resp.StatusCode >= 400 {
+		return c.HandleErrorResponse(resp)
+	}
+
+	return nil
+}
+
+// OrganizationResponse represents a Make.com organization from the API
+type OrganizationResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// OrganizationRequest represents the request payload for creating/updating organizations
+type OrganizationRequest struct {
+	Name string `json:"name"`
+}
+
+// CreateOrganization creates a new organization in Make.com
+func (c *MakeAPIClient) CreateOrganization(ctx context.Context, req OrganizationRequest) (*OrganizationResponse, error) {
+	resp, err := c.MakeRequest(ctx, "POST", "v2/organizations", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, c.HandleErrorResponse(resp)
+	}
+
+	var org OrganizationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&org); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &org, nil
+}
+
+// GetOrganization retrieves an organization by ID from Make.com
+func (c *MakeAPIClient) GetOrganization(ctx context.Context, id string) (*OrganizationResponse, error) {
+	endpoint := fmt.Sprintf("v2/organizations/%s", id)
+	resp, err := c.MakeRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("organization with ID %s not found", id)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, c.HandleErrorResponse(resp)
+	}
+
+	var org OrganizationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&org); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &org, nil
+}
+
+// UpdateOrganization updates an existing organization in Make.com
+func (c *MakeAPIClient) UpdateOrganization(ctx context.Context, id string, req OrganizationRequest) (*OrganizationResponse, error) {
+	endpoint := fmt.Sprintf("v2/organizations/%s", id)
+	resp, err := c.MakeRequest(ctx, "PUT", endpoint, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("organization with ID %s not found", id)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, c.HandleErrorResponse(resp)
+	}
+
+	var org OrganizationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&org); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &org, nil
+}
+
+// DeleteOrganization deletes an organization from Make.com
+func (c *MakeAPIClient) DeleteOrganization(ctx context.Context, id string) error {
+	endpoint := fmt.Sprintf("v2/organizations/%s", id)
+	resp, err := c.MakeRequest(ctx, "DELETE", endpoint, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		// Already deleted or doesn't exist
+		return nil
+	}
+
+	if resp.StatusCode >= 400 {
+		return c.HandleErrorResponse(resp)
+	}
+
+	return nil
+}

--- a/internal/provider/organization_data_source.go
+++ b/internal/provider/organization_data_source.go
@@ -1,0 +1,92 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ datasource.DataSource = &OrganizationDataSource{}
+
+func NewOrganizationDataSource() datasource.DataSource {
+	return &OrganizationDataSource{}
+}
+
+// OrganizationDataSource defines the data source implementation.
+type OrganizationDataSource struct {
+	client *MakeAPIClient
+}
+
+// OrganizationDataSourceModel describes the data source data model.
+type OrganizationDataSourceModel struct {
+	Id   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+func (d *OrganizationDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_organization"
+}
+
+func (d *OrganizationDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Make.com organization data source",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "Organization identifier",
+				Required:            true,
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Name of the organization",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (d *OrganizationDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*MakeAPIClient)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *MakeAPIClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}
+
+func (d *OrganizationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data OrganizationDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org, err := d.client.GetOrganization(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read organization, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(org.ID)
+	data.Name = types.StringValue(org.Name)
+
+	tflog.Trace(ctx, "read an organization data source")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/organization_resource.go
+++ b/internal/provider/organization_resource.go
@@ -1,0 +1,171 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &OrganizationResource{}
+var _ resource.ResourceWithImportState = &OrganizationResource{}
+
+func NewOrganizationResource() resource.Resource {
+	return &OrganizationResource{}
+}
+
+// OrganizationResource defines the resource implementation.
+type OrganizationResource struct {
+	client *MakeAPIClient
+}
+
+// OrganizationResourceModel describes the resource data model.
+type OrganizationResourceModel struct {
+	Id   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+func (r *OrganizationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_organization"
+}
+
+func (r *OrganizationResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Make.com organization resource",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Organization identifier",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Name of the organization",
+				Required:            true,
+			},
+		},
+	}
+}
+
+func (r *OrganizationResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*MakeAPIClient)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *MakeAPIClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *OrganizationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data OrganizationResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiReq := OrganizationRequest{
+		Name: data.Name.ValueString(),
+	}
+
+	org, err := r.client.CreateOrganization(ctx, apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create organization, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(org.ID)
+	data.Name = types.StringValue(org.Name)
+
+	tflog.Trace(ctx, "created an organization resource")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *OrganizationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data OrganizationResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org, err := r.client.GetOrganization(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read organization, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(org.ID)
+	data.Name = types.StringValue(org.Name)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *OrganizationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data OrganizationResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiReq := OrganizationRequest{
+		Name: data.Name.ValueString(),
+	}
+
+	org, err := r.client.UpdateOrganization(ctx, data.Id.ValueString(), apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update organization, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(org.ID)
+	data.Name = types.StringValue(org.Name)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *OrganizationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data OrganizationResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteOrganization(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete organization, got error: %s", err))
+		return
+	}
+
+	tflog.Trace(ctx, "deleted an organization resource")
+}
+
+func (r *OrganizationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -108,6 +108,8 @@ func (p *MakeProvider) Resources(ctx context.Context) []func() resource.Resource
 		NewScenarioResource,
 		NewConnectionResource,
 		NewWebhookResource,
+		NewTeamResource,
+		NewOrganizationResource,
 	}
 }
 
@@ -115,6 +117,8 @@ func (p *MakeProvider) DataSources(ctx context.Context) []func() datasource.Data
 	return []func() datasource.DataSource{
 		NewScenarioDataSource,
 		NewConnectionDataSource,
+		NewTeamDataSource,
+		NewOrganizationDataSource,
 	}
 }
 

--- a/internal/provider/resource_test.go
+++ b/internal/provider/resource_test.go
@@ -115,3 +115,73 @@ resource "make_webhook" "test" {
 }
 `
 }
+
+func TestAccTeamResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamResourceConfig("example"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("make_team.test", "name", "Test Team example"),
+					resource.TestCheckResourceAttrSet("make_team.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "make_team.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTeamResourceConfig("updated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("make_team.test", "name", "Test Team updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTeamResourceConfig(suffix string) string {
+	return `
+resource "make_team" "test" {
+  name = "Test Team ` + suffix + `"
+}
+`
+}
+
+func TestAccOrganizationResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationResourceConfig("example"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("make_organization.test", "name", "Test Organization example"),
+					resource.TestCheckResourceAttrSet("make_organization.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "make_organization.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccOrganizationResourceConfig("updated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("make_organization.test", "name", "Test Organization updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOrganizationResourceConfig(suffix string) string {
+	return `
+resource "make_organization" "test" {
+  name = "Test Organization ` + suffix + `"
+}
+`
+}

--- a/internal/provider/team_data_source.go
+++ b/internal/provider/team_data_source.go
@@ -1,0 +1,104 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ datasource.DataSource = &TeamDataSource{}
+
+func NewTeamDataSource() datasource.DataSource {
+	return &TeamDataSource{}
+}
+
+// TeamDataSource defines the data source implementation.
+type TeamDataSource struct {
+	client *MakeAPIClient
+}
+
+// TeamDataSourceModel describes the data source data model.
+type TeamDataSourceModel struct {
+	Id             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	OrganizationId types.String `tfsdk:"organization_id"`
+}
+
+func (d *TeamDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_team"
+}
+
+func (d *TeamDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Make.com team data source",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "Team identifier",
+				Required:            true,
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Name of the team",
+				Computed:            true,
+			},
+			"organization_id": schema.StringAttribute{
+				MarkdownDescription: "Organization ID where the team belongs",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (d *TeamDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*MakeAPIClient)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *MakeAPIClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}
+
+func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data TeamDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	team, err := d.client.GetTeam(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(team.ID)
+	data.Name = types.StringValue(team.Name)
+
+	if team.OrganizationID != "" {
+		data.OrganizationId = types.StringValue(team.OrganizationID)
+	} else {
+		data.OrganizationId = types.StringNull()
+	}
+
+	tflog.Trace(ctx, "read a team data source")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -1,0 +1,205 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &TeamResource{}
+var _ resource.ResourceWithImportState = &TeamResource{}
+
+func NewTeamResource() resource.Resource {
+	return &TeamResource{}
+}
+
+// TeamResource defines the resource implementation.
+type TeamResource struct {
+	client *MakeAPIClient
+}
+
+// TeamResourceModel describes the resource data model.
+type TeamResourceModel struct {
+	Id             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	OrganizationId types.String `tfsdk:"organization_id"`
+}
+
+func (r *TeamResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_team"
+}
+
+func (r *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Make.com team resource",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Team identifier",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Name of the team",
+				Required:            true,
+			},
+			"organization_id": schema.StringAttribute{
+				MarkdownDescription: "Organization ID where the team belongs",
+				Optional:            true,
+			},
+		},
+	}
+}
+
+func (r *TeamResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*MakeAPIClient)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *MakeAPIClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data TeamResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Prepare the API request
+	apiReq := TeamRequest{
+		Name: data.Name.ValueString(),
+	}
+
+	if !data.OrganizationId.IsNull() {
+		apiReq.OrganizationID = data.OrganizationId.ValueString()
+	}
+
+	// Create the team via API
+	team, err := r.client.CreateTeam(ctx, apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create team, got error: %s", err))
+		return
+	}
+
+	// Map response to Terraform state
+	data.Id = types.StringValue(team.ID)
+	data.Name = types.StringValue(team.Name)
+
+	if team.OrganizationID != "" {
+		data.OrganizationId = types.StringValue(team.OrganizationID)
+	}
+
+	// Write logs using the tflog package
+	tflog.Trace(ctx, "created a team resource")
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data TeamResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	team, err := r.client.GetTeam(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(team.ID)
+	data.Name = types.StringValue(team.Name)
+
+	if team.OrganizationID != "" {
+		data.OrganizationId = types.StringValue(team.OrganizationID)
+	} else {
+		data.OrganizationId = types.StringNull()
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data TeamResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiReq := TeamRequest{
+		Name: data.Name.ValueString(),
+	}
+
+	if !data.OrganizationId.IsNull() {
+		apiReq.OrganizationID = data.OrganizationId.ValueString()
+	}
+
+	team, err := r.client.UpdateTeam(ctx, data.Id.ValueString(), apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update team, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(team.ID)
+	data.Name = types.StringValue(team.Name)
+
+	if team.OrganizationID != "" {
+		data.OrganizationId = types.StringValue(team.OrganizationID)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *TeamResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data TeamResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteTeam(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete team, got error: %s", err))
+		return
+	}
+
+	tflog.Trace(ctx, "deleted a team resource")
+}
+
+func (r *TeamResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}


### PR DESCRIPTION
## Summary
- add API client support for teams and organizations
- introduce make_team and make_organization resources and data sources
- document team and organization management and update roadmap

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68bee8190474832c8f3c302a66872136