### PR TITLE
Add acceptance tests for data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,5 +397,5 @@ This provider is designed to work with the Make.com API. For more information ab
 - [x] Add basic test coverage
 - [x] Add team and organization management
 - [x] Add data store management
-- [ ] Add more comprehensive test coverage including acceptance tests
+- [x] Add more comprehensive test coverage including acceptance tests
 - [ ] Add advanced configuration options for webhooks and connections

--- a/internal/provider/data_source_test.go
+++ b/internal/provider/data_source_test.go
@@ -1,0 +1,151 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccScenarioDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScenarioDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.make_scenario.test", "name", "Test Scenario"),
+					resource.TestCheckResourceAttr("data.make_scenario.test", "description", "Test scenario description"),
+					resource.TestCheckResourceAttr("data.make_scenario.test", "active", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccScenarioDataSourceConfig() string {
+	return `
+resource "make_scenario" "test" {
+  name        = "Test Scenario"
+  description = "Test scenario description"
+  active      = true
+}
+
+data "make_scenario" "test" {
+  id = make_scenario.test.id
+}
+`
+}
+
+func TestAccConnectionDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectionDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.make_connection.test", "name", "Test Connection"),
+					resource.TestCheckResourceAttr("data.make_connection.test", "app_name", "gmail"),
+					resource.TestCheckResourceAttrSet("data.make_connection.test", "verified"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConnectionDataSourceConfig() string {
+	return `
+resource "make_connection" "test" {
+  name     = "Test Connection"
+  app_name = "gmail"
+}
+
+data "make_connection" "test" {
+  id = make_connection.test.id
+}
+`
+}
+
+func TestAccTeamDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.make_team.test", "name", "Test Team"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTeamDataSourceConfig() string {
+	return `
+resource "make_team" "test" {
+  name = "Test Team"
+}
+
+data "make_team" "test" {
+  id = make_team.test.id
+}
+`
+}
+
+func TestAccOrganizationDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.make_organization.test", "name", "Test Organization"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOrganizationDataSourceConfig() string {
+	return `
+resource "make_organization" "test" {
+  name = "Test Organization"
+}
+
+data "make_organization" "test" {
+  id = make_organization.test.id
+}
+`
+}
+
+func TestAccDataStoreDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataStoreDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.make_data_store.test", "name", "Test Data Store"),
+					resource.TestCheckResourceAttr("data.make_data_store.test", "description", "Test data store description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataStoreDataSourceConfig() string {
+	return `
+resource "make_data_store" "test" {
+  name        = "Test Data Store"
+  description = "Test data store description"
+}
+
+data "make_data_store" "test" {
+  id = make_data_store.test.id
+}
+`
+}


### PR DESCRIPTION
## Summary
- extend test suite with acceptance tests for scenario, connection, team, organization and data store data sources
- mark roadmap item for comprehensive test coverage as complete

## Testing
- `TF_ACC=1 go test ./internal/provider -run TestAccScenarioDataSource -v` *(fails: Invalid provider configuration; Missing API Token configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68beefb0dba4832caf4f211951dbbdb0